### PR TITLE
fix Adj for ADJ validator compatibility

### DIFF
--- a/.github/workflows/scripts/adj-tester/main.py
+++ b/.github/workflows/scripts/adj-tester/main.py
@@ -2,7 +2,7 @@
 
 ADJ Validator
 
-Version: 1.1.0
+Version: 11.1.2
 
 JavierRibaldelRio
 
@@ -381,7 +381,9 @@ def check_measurement_json(path: str, previous_ids=None):
     return is_valid
 
 
-def check_packet_json(path: str, sockets: set, measurement_ids=None):
+def check_packet_json(
+    path: str, sockets: set, measurement_ids=None, used_measurement_ids=None
+):
     """Validate a packet JSON file.
 
     Ensures schema conformance, global uniqueness of packet IDs
@@ -429,6 +431,10 @@ def check_packet_json(path: str, sockets: set, measurement_ids=None):
                         )
                     )
                     is_valid = False
+                else:
+                    # Track that this measurement is being used
+                    if used_measurement_ids is not None:
+                        used_measurement_ids.add(meas_id)
 
             # Ensure that socket is defined in the sockets
             socket_name = pkt.get("socket", "")
@@ -494,7 +500,13 @@ def check_socket_json(path: str, sockets_name: set):
 
             else:
                 socket_ip = socket.get("remote_ip", "")
-                if socket_ip != "" and not is_valid_ipv4(socket_ip):
+
+                # Remote ip might also be backend
+                if (
+                    socket_ip != ""
+                    and not is_valid_ipv4(socket_ip)
+                    and socket_ip.lower() != "backend"
+                ):
                     error_list.append(
                         logError(
                             path,
@@ -591,6 +603,7 @@ def main():
 
             # measurements are unique within a board
             measurement_ids = set()
+            used_measurement_ids = set()
 
             # sockets are unique
             sockets_name = set()
@@ -621,8 +634,32 @@ def main():
                         f"boards/{board_name}/{packets_path}",
                         sockets_name,
                         measurement_ids,
+                        used_measurement_ids,
                     )
                     and valid
+                )
+
+            # Check for measurements that are defined but not used
+            unused_measurements = measurement_ids - used_measurement_ids
+            unused_error_list = []
+            if unused_measurements:
+                for measurement_id in sorted(unused_measurements):
+                    unused_error_list.append(
+                        logError(
+                            f"{board_name} - GENERAL INFO",
+                            f"measurement id '{measurement_id}'",
+                            f"Measurement id '{measurement_id}' is defined but never used in any packet or order",
+                        )
+                    )
+                valid = False
+
+            if unused_error_list:
+                print_results(
+                    f"boards/{board_name}",
+                    False,
+                    unused_error_list,
+                    type="(Unused Measurements)",
+                    prefix="\t",
                 )
         else:
             log_message(

--- a/.github/workflows/scripts/adj-tester/schema/packet.schema.json
+++ b/.github/workflows/scripts/adj-tester/schema/packet.schema.json
@@ -37,12 +37,20 @@
                 },
                 "description": "Measurement IDs included in this packet"
             },
-            "period_ms": {
+            "period": {
                 "type": [
                     "integer",
                     "number"
                 ],
                 "description": "Packet transmission period in milliseconds"
+            },
+            "period_type": {
+                "type": "string",
+                "enum": [
+                    "us",
+                    "ms"
+                ],
+                "description": "Unit type for period (microseconds or milliseconds)"
             },
             "socket": {
                 "type": "string",

--- a/.github/workflows/scripts/adj-tester/schema/socket.schema.json
+++ b/.github/workflows/scripts/adj-tester/schema/socket.schema.json
@@ -40,7 +40,6 @@
             },
             "remote_ip": {
                 "type": "string",
-                "format": "ipv4",
                 "description": "Remote IPv4 address"
             },
             "remote_port": {

--- a/boards/BCU/measurements.json
+++ b/boards/BCU/measurements.json
@@ -1,40 +1,5 @@
 [
     {
-        "id": "output_duty_cycle_u",
-        "name": "Duty Cycle U",
-        "type": "float32",
-        "podUnits": "%",
-        "displayUnits": "%"
-    },
-    {
-        "id": "output_duty_cycle_v",
-        "name": "Duty Cycle V",
-        "type": "float32",
-        "podUnits": "%",
-        "displayUnits": "%"
-    },
-    {
-        "id": "output_duty_cycle_w",
-        "name": "Duty Cycle W",
-        "type": "float32",
-        "podUnits": "%",
-        "displayUnits": "%"
-    },
-    {
-        "id": "output_commutation_frequency_hz",
-        "name": "Commutation Frequency",
-        "type": "uint32",
-        "podUnits": "Hz",
-        "displayUnits": "Hz"
-    },
-    {
-        "id": "output_dead_time_ns",
-        "name": "Dead Time",
-        "type": "uint32",
-        "podUnits": "ns",
-        "displayUnits": "ns"
-    },
-    {
         "id": "bcu_general_state",
         "name": "General State",
         "type": "enum",
@@ -307,66 +272,6 @@
         "type": "bool"
     },
     {
-        "id": "position_speetec_2",
-        "name": "Position Speetec 2",
-        "type": "float64",
-        "podUnits": "m",
-        "displayUnits": "m"
-    },
-    {
-        "id": "speed_speetec_2",
-        "name": "Speed Speetec 2",
-        "type": "float64",
-        "podUnits": "m/s",
-        "displayUnits": "m/s"
-    },
-    {
-        "id": "acceleration_speetec_2",
-        "name": "Acceleration Speetec 2",
-        "type": "float64",
-        "podUnits": "m/ss",
-        "displayUnits": "m/ss"
-    },
-    {
-        "id": "direction_speetec_2",
-        "name": "Direction Speetec 2",
-        "type": "enum",
-        "enumValues": [
-            "Forward",
-            "Backward"
-        ]
-    },
-    {
-        "id": "position_speetec_3",
-        "name": "Position Speetec 3",
-        "type": "float64",
-        "podUnits": "m",
-        "displayUnits": "m"
-    },
-    {
-        "id": "speed_speetec_3",
-        "name": "Speed Speetec 3",
-        "type": "float64",
-        "podUnits": "m/s",
-        "displayUnits": "m/s"
-    },
-    {
-        "id": "acceleration_speetec_3",
-        "name": "Acceleration Speetec 3",
-        "type": "float64",
-        "podUnits": "m/ss",
-        "displayUnits": "m/ss"
-    },
-    {
-        "id": "direction_speetec_3",
-        "name": "Direction Speetec 3",
-        "type": "enum",
-        "enumValues": [
-            "Forward",
-            "Backward"
-        ]
-    },
-    {
         "id": "d_current_reference",
         "name": "D Current Reference",
         "type": "float64",
@@ -449,12 +354,5 @@
         "type": "float64",
         "podUnits": "rad",
         "displayUnits": "rad"
-    },
-    {
-        "id": "target_linear_speed",
-        "name": "Target Linear Speed (m/s)",
-        "type": "float32",
-        "podUnits": "m/s",
-        "displayUnits": "m/s"
     }
 ]

--- a/boards/BCU/order_measurements.json
+++ b/boards/BCU/order_measurements.json
@@ -102,32 +102,6 @@
         }
     },
     {
-        "id": "requested_d_current_reference",
-        "name": "D Current Reference (A)",
-        "type": "float32",
-        "podUnits": "A",
-        "displayUnits": "A",
-        "out_of_range": {
-            "warning": [
-                0.0,
-                80.0
-            ]
-        }
-    },
-    {
-        "id": "requested_q_current_reference",
-        "name": "Q Current Reference (A)",
-        "type": "float32",
-        "podUnits": "A",
-        "displayUnits": "A",
-        "out_of_range": {
-            "warning": [
-                0.0,
-                80.0
-            ]
-        }
-    },
-    {
         "id": "requested_d_current_reference_2",
         "name": "D Current Reference(A)",
         "type": "float32",

--- a/boards/LCU/LCU_measurements.json
+++ b/boards/LCU/LCU_measurements.json
@@ -20,13 +20,6 @@
     ]
   },
   {
-    "id": "lcu_battery_voltage",
-    "name": "Battery Voltage to set",
-    "type": "float32",
-    "podUnits": "V",
-    "displayUnits": "V"
-  },
-  {
     "id": "lcu_desired_current",
     "name": "Desired current to set",
     "type": "float32",
@@ -45,146 +38,6 @@
     "id": "ldu_buffer_id",
     "name": "LDU Buffer ID",
     "type": "uint8"
-  },
-  {
-    "id": "lcu_coil_temp_1",
-    "name": "Temperature on LDU 1 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_2",
-    "name": "Temperature on LDU 2 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_3",
-    "name": "Temperature on LDU 3 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_4",
-    "name": "Temperature on LDU 4 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_5",
-    "name": "Temperature on LDU 5 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_6",
-    "name": "Temperature on LDU 6 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_7",
-    "name": "Temperature on LDU 7 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_8",
-    "name": "Temperature on LDU 8 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_9",
-    "name": "Temperature on LDU 9 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_coil_temp_10",
-    "name": "Temperature on LDU 10 coil",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_1",
-    "name": "Temperature on LPU 1",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_2",
-    "name": "Temperature on LPU 2",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_3",
-    "name": "Temperature on LPU 3",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_4",
-    "name": "Temperature on LPU 4",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_5",
-    "name": "Temperature on LPU 5",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_6",
-    "name": "Temperature on LPU 6",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_7",
-    "name": "Temperature on LPU 7",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_8",
-    "name": "Temperature on LPU 8",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_9",
-    "name": "Temperature on LPU 9",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
-  },
-  {
-    "id": "lcu_driver_temp_10",
-    "name": "Temperature on LPU 10",
-    "type": "float32",
-    "podUnits": "ºC",
-    "displayUnits": "ºC"
   },
   {
     "id": "lcu_coil_current_1",
@@ -513,62 +366,6 @@
     "displayUnits": "deg"
   },
   {
-    "id": "test_gui__1",
-    "name": "Airgap BUENO 1",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui__2",
-    "name": "Airgap BUENO 2",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui_3_",
-    "name": "Airgap BUENO 3",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui_4_",
-    "name": "Airgap BUENO 4",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui_5_",
-    "name": "Airgap BUENO 5",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui_6_",
-    "name": "Airgap BUENO 6",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui_7_",
-    "name": "Airgap BUENO 7",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "test_gui_8_",
-    "name": "Airgap BUENO 8",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
-  },
-  {
     "id": "lcu_desired_distance",
     "name": "desired distance (mm)",
     "type": "float32",
@@ -576,120 +373,8 @@
     "displayUnits": "mm"
   },
   {
-    "id": "pos_y",
-    "name": "Y pos meters",
-    "type": "float32",
-    "podUnits": "m",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "pos_z",
-    "name": "Z pos meters",
-    "type": "float32",
-    "podUnits": "m",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "pos_rot_x",
-    "name": "X rotation radians",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_rot_y",
-    "name": "Y rotation radians",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_rot_z",
-    "name": "Z rotation radians",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_y_d",
-    "name": "Y pos derivative",
-    "type": "float32",
-    "podUnits": "m",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "pos_z_d",
-    "name": "Z pos derivative",
-    "type": "float32",
-    "podUnits": "m",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "pos_rot_x_d",
-    "name": "X rotation derivative",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_rot_y_d",
-    "name": "Y rotation derivative",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_rot_z_d",
-    "name": "Z rotation derivative",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_y_i",
-    "name": "Y pos integral",
-    "type": "float32",
-    "podUnits": "m",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "pos_z_i",
-    "name": "Z pos integral",
-    "type": "float32",
-    "podUnits": "m",
-    "displayUnits": "mm"
-  },
-  {
-    "id": "pos_rot_x_i",
-    "name": "X rotation integral",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_rot_y_i",
-    "name": "Y rotation integral",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
-    "id": "pos_rot_z_i",
-    "name": "Z rotation integral",
-    "type": "float32",
-    "podUnits": "rad",
-    "displayUnits": "mrad"
-  },
-  {
     "id": "current_control_frequency",
     "name": "current control frequency",
-    "type": "uint32",
-    "podUnits": "Hz",
-    "displayUnits": "Hz"
-  },
-  {
-    "id": "levitation_control_frequency",
-    "name": "levitation control frequency",
     "type": "uint32",
     "podUnits": "Hz",
     "displayUnits": "Hz"
@@ -867,11 +552,6 @@
     "displayUnits": "A"
   },
   {
-    "id": "output_voltage",
-    "name": "output_voltage",
-    "type": "uint16"
-  },
-  {
     "id": "lcu_dis_pos_ref_1",
     "name": "Ref Dis 1",
     "type": "float32",
@@ -982,13 +662,6 @@
     "type": "float32",
     "podUnits": "A",
     "displayUnits": "A"
-  },
-  {
-    "id": "noise_for_hems",
-    "name": "noise for hems",
-    "type": "float32",
-    "podUnits": "mm",
-    "displayUnits": "mm"
   },
   {
     "id": "multi_current_1",

--- a/boards/PCU/PCU_measurements.json
+++ b/boards/PCU/PCU_measurements.json
@@ -248,15 +248,6 @@
     "displayUnits": "A"
   },
   {
-    "id": "Current_Control_State",
-    "name": "Current Control State",
-    "type": "enum",
-    "enumValues": [
-      "Cruise_Mode",
-      "Regenerate_Mode"
-    ]
-  },
-  {
     "id": "Speed_Control_State",
     "name": "Control Current ref",
     "type": "enum",


### PR DESCRIPTION
New version of ADJ-validator will force to remove unused measurements. 

In this PR the ADJ is fixed by removing the unused measurements from: LCU, PCU and BCU