### PR TITLE
Rename brake_fault_detected to brakes_status as BrakesStatus enum (BR…

### DIFF
--- a/boards/VCU/VCU_measurements.json
+++ b/boards/VCU/VCU_measurements.json
@@ -48,9 +48,13 @@
         "type": "bool"
     },
     {
-        "id": "brake_fault_detected",
-        "name": "Brake Fault Detected",
-        "type": "bool"
+        "id": "brakes_status",
+        "name": "Brakes Status",
+        "type": "enum",
+        "enumValues": [
+            "BRAKED",
+            "UNBRAKED"
+        ]
     },
     {
         "id": "electrovalve_enabled",

--- a/boards/VCU/packets.json
+++ b/boards/VCU/packets.json
@@ -28,7 +28,7 @@
         "name": "Brake Status",
         "variables": [
             "active_brakes",
-            "brake_fault_detected"
+            "brakes_status"
         ],
         "id": 253,
         "period_type": "ms",


### PR DESCRIPTION
Modified brakes packets and measurements to define the brakes status as an enum (BRAKED/UNBRAKED), instead of using a bool that can lead to misunderstandings